### PR TITLE
line bot now search if a LINE group ID is already registed to a household then assign user to that household

### DIFF
--- a/app/controllers/linebots_controller.rb
+++ b/app/controllers/linebots_controller.rb
@@ -72,7 +72,7 @@ class LinebotsController < ApplicationController
       when Line::Bot::Event::MessageType::Text
         if event['source']['groupId']
           group_line_id = event['source']['groupId']
-          unless Household.exists?(line_id: id)
+          unless Household.exists?(line_id: group_line_id)
             household = Household.create(line_id: group_line_id)
             user.update(household_id: household.id)  # update household LINE ID everytime this user added Pantry bot to a new group
           end


### PR DESCRIPTION
debug typo 🤦🏻‍♀️ that created a new household every time a user add the LINE bot to a family group (by inviting it and then calling 'Pantry')﻿
